### PR TITLE
hbbtv-webkit: Don't install *.pyc files in __pycache__ directory

### DIFF
--- a/recipes-webkit/webkit/enigma2-plugin-extensions-hbbtv-webkit.bb
+++ b/recipes-webkit/webkit/enigma2-plugin-extensions-hbbtv-webkit.bb
@@ -35,7 +35,7 @@ do_install_append() {
     
     # Python Files
     cp -arf --no-preserve=ownership ${S}/HbbTV/* ${D}/usr/lib/${DESTDIR}
-    python3 -O -m compileall ${D}/usr/lib/${DESTDIR}
+    python3 -m compileall -b ${D}/usr/lib/${DESTDIR}
     rm -rf ${D}/usr/lib/${DESTDIR}/*.py
     
     # browser


### PR DESCRIPTION
With file names like aitreader.cpython-312.opt-1.pyc.